### PR TITLE
Replace Postmark with Resend for email delivery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ gem "hashid-rails", "~> 1.0"
 # Brings Rails named routes to javascript
 gem "js-routes"
 
-# Postmark for production email delivery
-gem "postmark-rails"
+# Resend for production email delivery
+gem "resend"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -144,6 +145,10 @@ GEM
       activerecord (>= 4.0)
       hashids (~> 1.0)
     hashids (1.0.6)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     inertia_rails (3.10.0)
@@ -198,6 +203,8 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     net-http (0.6.0)
@@ -242,11 +249,6 @@ GEM
     pg (1.6.1-arm64-darwin)
     pg (1.6.1-x86_64-linux)
     pg (1.6.1-x86_64-linux-musl)
-    postmark (1.25.1)
-      json
-    postmark-rails (0.22.1)
-      actionmailer (>= 3.0.0)
-      postmark (>= 1.21.3, < 2.0)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -311,6 +313,9 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    resend (1.3.0)
+      base64
+      httparty (>= 0.22.0)
     rexml (3.4.1)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
@@ -460,10 +465,10 @@ DEPENDENCIES
   kamal
   letter_opener
   pg (>= 1.6)
-  postmark-rails
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  resend
   rspec-rails (~> 8.0)
   rubocop-rails-omakase
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modern full-stack starter application with Rails backend and React frontend us
 - [Inertia Rails](https://inertia-rails.dev) & [Vite Rails](https://vite-ruby.netlify.app) setup
 - [React](https://react.dev) frontend with TypeScript & [shadcn/ui](https://ui.shadcn.com) component library
 - [Clerk](https://clerk.com) User authentication system
-- Email delivery with [Postmark](https://postmarkapp.com) (production) and [letter_opener](https://github.com/ryanb/letter_opener) (development)
+- Email delivery with [Resend](https://resend.com) (production) and [letter_opener](https://github.com/ryanb/letter_opener) (development)
 - [Kamal](https://kamal-deploy.org/) for deployment
 - Optional SSR support
 
@@ -40,37 +40,37 @@ clerk:
   api_key: "sk_test_your_secret_key_here"  # Your Clerk secret key
 
 # For production email delivery
-postmark:
-  api_token: "your_postmark_server_api_token_here"
+resend:
+  api_key: "your_resend_api_key_here"
 ```
 
 #### Email Delivery
 - `FROM_EMAIL` - Email address used as sender for all outgoing emails
-  - Must be verified in your Postmark account for production
+  - Must use a verified domain in your Resend account for production
   - Default: `noreply@example.com`
 - `HOST` - Your application's domain name for generating links in emails (production)
 
-**Email Setup:** This application uses **Postmark** for production email delivery and **letter_opener** for development email preview.
+**Email Setup:** This application uses **Resend** for production email delivery and **letter_opener** for development email preview.
 
 **Development:** No setup required - emails automatically open in your browser.
 
 **Production Setup:**
-1. Sign up for a [Postmark account](https://postmarkapp.com/) and create a server
-2. Add your Postmark API token to Rails credentials:
+1. Sign up for a [Resend account](https://resend.com/) and create an API key
+2. Add your Resend API key to Rails credentials:
    ```bash
    rails credentials:edit
    ```
    Add:
    ```yaml
-   postmark:
-     api_token: "your_postmark_server_api_token_here"
+   resend:
+     api_key: "your_resend_api_key_here"
    ```
 3. Set environment variables:
    ```bash
    FROM_EMAIL=noreply@yourdomain.com
    HOST=yourdomain.com
    ```
-4. Verify the sender signature in your Postmark account
+4. Verify your sending domain in your Resend account
 
 
 ### Optional Environment Variables

--- a/config/credentials.yml.example
+++ b/config/credentials.yml.example
@@ -3,9 +3,9 @@
 
 secret_key_base: abc123
 
-# For production, add your Postmark API token:
-postmark:
-  api_token: your_postmark_server_api_token_here
+# For production, add your Resend API key:
+resend:
+  api_key: your_resend_api_key_here
 
 # Clerk Authentication
 clerk:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,15 +58,10 @@ Rails.application.configure do
   # Configure email delivery for production
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :postmark
+  config.action_mailer.delivery_method = :resend
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = {host: ENV.fetch("HOST", "example.com")}
-
-  # Configure Postmark for email delivery
-  config.action_mailer.postmark_settings = {
-    api_token: Rails.application.credentials.dig(:postmark, :api_token)
-  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Configure Resend for production email delivery.
+# See https://resend.com/docs/send-with-rails
+Resend.api_key = Rails.application.credentials.dig(:resend, :api_key) || ENV["RESEND_API_KEY"]

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -9,14 +9,14 @@ namespace :email do
     puts "Default from address: #{ApplicationMailer.default[:from]}"
 
     if Rails.env.production?
-      api_token = Rails.application.credentials.dig(:postmark, :api_token)
-      if api_token.present?
-        puts "✅ Postmark API token is configured"
-        puts "API token: #{api_token[0..6]}..." # Show only first 7 characters for security
+      api_key = Rails.application.credentials.dig(:resend, :api_key) || ENV["RESEND_API_KEY"]
+      if api_key.present?
+        puts "✅ Resend API key is configured"
+        puts "API key: #{api_key[0..6]}..." # Show only first 7 characters for security
       else
-        puts "❌ Postmark API token is missing from credentials"
+        puts "❌ Resend API key is missing from credentials"
         puts "Run: EDITOR='your_editor' rails credentials:edit"
-        puts "Add: postmark:\n       api_token: your_token_here"
+        puts "Add: resend:\n       api_key: your_api_key_here"
       end
     end
 

--- a/spec/config/credentials_spec.rb
+++ b/spec/config/credentials_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Credentials structure" do
       expect(parsed_credentials.dig("clerk", "webhook_secret")).to be_present
     end
 
-    it "includes postmark configuration" do
-      expect(parsed_credentials.dig("postmark", "api_token")).to be_present
+    it "includes resend configuration" do
+      expect(parsed_credentials.dig("resend", "api_key")).to be_present
     end
 
     it "includes sentry configuration" do


### PR DESCRIPTION
- Swap postmark-rails gem for resend gem (Gemfile/Gemfile.lock)
- Use :resend delivery method in production and add Resend initializer
  reading credentials/RESEND_API_KEY
- Update credentials example, email rake task, and credentials spec to
  the resend.api_key shape
- Update README setup instructions to Resend

https://claude.ai/code/session_016ttZo9xZexeKTTLuLHNiH2