### PR TITLE
Extract Clerk auth resolution into a service object

### DIFF
--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -15,14 +15,14 @@ module Authenticatable
   end
   alias require_clerk_session! authenticate_user!
 
-  def current_user
-    return @current_user if defined?(@current_user)
+  # Memoized per request; user/org/role are each resolved lazily on first access,
+  # so requests that only need the user don't pay for an Org lookup.
+  def clerk_auth
+    @clerk_auth ||= ClerkAuthenticationResolver.call(clerk)
+  end
 
-    if clerk && (user_id = clerk.user_id)
-      @current_user = User.find_or_create_by(clerk_id: user_id)
-    else
-      @current_user = nil
-    end
+  def current_user
+    clerk_auth.user
   end
 
   def clerk_user
@@ -36,24 +36,15 @@ module Authenticatable
   end
 
   def current_org
-    return @current_org if defined?(@current_org)
-
-    if !Rails.env.test? && (org_id = clerk.organization_id)
-      @current_org = Org.find_or_create_by(clerk_org_id: org_id)
-    else
-      @current_org = nil
-    end
+    clerk_auth.org
   end
 
   def org_account?
     current_org.present?
   end
 
+  # The user's role in the active org, read live from the Clerk token.
   def current_user_org_role
-    if org_account? && !Rails.env.test?
-      clerk.organization_role
-    else
-      nil
-    end
+    clerk_auth.role
   end
 end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -61,7 +61,7 @@ class WebhooksController < ApplicationController
     user = User.find_by(clerk_id: clerk_user_id)
     if user
       # Clear the cached Clerk user data so it gets refreshed on next access
-      Rails.cache.delete("clerk_user/#{clerk_user_id}")
+      Rails.cache.delete(User.clerk_cache_key(clerk_user_id))
       Rails.logger.info("Cleared cache for updated user #{user.id}")
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,15 @@
 class User < ApplicationRecord
   include Hashid::Rails
 
+  # Safety net only — the user.updated webhook invalidates this cache, so a long
+  # TTL just risks serving stale profiles when a webhook is missed/fails.
+  CLERK_CACHE_TTL = 1.hour
+
   validates :clerk_id, presence: true, uniqueness: true
+
+  def self.clerk_cache_key(clerk_id)
+    "clerk_user/#{clerk_id}"
+  end
 
   def clerk_user
     @clerk_user ||= fetch_clerk_user
@@ -40,8 +48,8 @@ class User < ApplicationRecord
   def fetch_clerk_user
     return nil if Rails.env.test? # Skip API calls in test
 
-    # Cache for longer period since we'll clear cache via webhook when Clerk user is updated
-    Rails.cache.fetch("clerk_user/#{clerk_id}", expires_in: 24.hours) do
+    # Cache the Clerk profile; the user.updated webhook clears this key on change.
+    Rails.cache.fetch(self.class.clerk_cache_key(clerk_id), expires_in: CLERK_CACHE_TTL) do
       Clerk::SDK.new.users.get_user(clerk_id)
     end
   rescue Clerk::Errors::Base => e

--- a/app/services/clerk_authentication_resolver.rb
+++ b/app/services/clerk_authentication_resolver.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Resolves the domain records (User, Org) for a request from the Clerk session
+# proxy. Extracted from the Authenticatable concern so the find-or-create-on-read
+# logic lives in one testable place.
+#
+# User and Org are thin local ID anchors so app-owned data can reference them by
+# foreign key — they intentionally do NOT mirror Clerk-managed data. The user's
+# role in the active org is read straight from the token (Clerk is the source of
+# truth) rather than persisted, so it can never drift.
+#
+# Each attribute is resolved lazily and memoized, so a caller that only needs the
+# user (the common path, via authenticate_user!) never pays for an Org lookup —
+# the org is found/created only when #org or #role is actually accessed.
+#
+# Organizations are optional: this works whether Clerk orgs are disabled entirely
+# (the proxy may not expose org methods at all) or enabled but the current user is
+# in a personal/no-org context. In those cases org and role are simply nil and the
+# user still resolves.
+class ClerkAuthenticationResolver
+  def self.call(clerk)
+    new(clerk)
+  end
+
+  def initialize(clerk)
+    @clerk = clerk
+  end
+
+  def user
+    return @user if defined?(@user)
+
+    @user = (user_id = clerk&.user_id) ? find_or_create(User, clerk_id: user_id) : nil
+  end
+
+  def org
+    return @org if defined?(@org)
+
+    @org = (org_id = clerk_organization_id) ? find_or_create(Org, clerk_org_id: org_id) : nil
+  end
+
+  def role
+    return @role if defined?(@role)
+
+    @role = clerk_organization_role
+  end
+
+  private
+
+  attr_reader :clerk
+
+  # find_or_create_by keeps the common path a single SELECT, but a concurrent
+  # first-time resolve can lose the INSERT race and raise RecordNotUnique (the
+  # unique index enforces it). Retry the lookup so that becomes a hit, not a 500.
+  #
+  # NOTE: create_or_find_by is unsuitable here — these models validate uniqueness,
+  # so on the common already-exists path its `create` fails validation, never
+  # issues an INSERT, and returns an invalid unsaved record instead of the row.
+  def find_or_create(model, attributes)
+    model.find_or_create_by(attributes)
+  rescue ActiveRecord::RecordNotUnique
+    model.find_by!(attributes)
+  end
+
+  # When Clerk orgs are disabled the proxy may not expose org methods at all,
+  # so guard with respond_to? before calling them.
+  def clerk_organization_id
+    return nil unless clerk.respond_to?(:organization_id)
+
+    clerk.organization_id
+  end
+
+  def clerk_organization_role
+    return nil unless clerk.respond_to?(:organization_role)
+
+    clerk.organization_role
+  end
+end

--- a/spec/factories/orgs.rb
+++ b/spec/factories/orgs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :org do
+    sequence(:clerk_org_id) { |n| "org_#{n}_clerk_org_id" }
+  end
+end

--- a/spec/services/clerk_authentication_resolver_spec.rb
+++ b/spec/services/clerk_authentication_resolver_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClerkAuthenticationResolver do
+  # Build a Clerk-proxy-like double. Pass include_role: false / include_org: false
+  # to omit the organization_role / organization_id messages entirely. Omitting
+  # the org messages mirrors a Clerk instance with organizations disabled, which
+  # the service must tolerate via respond_to?.
+  def clerk_double(user_id:, organization_id: nil, organization_role: nil, include_role: true, include_org: true)
+    attrs = {user_id:}
+    attrs[:organization_id] = organization_id if include_org
+    attrs[:organization_role] = organization_role if include_role
+    double("clerk_proxy", **attrs)
+  end
+
+  # A proxy from a Clerk instance with organizations disabled: no org methods.
+  def clerk_double_without_orgs(user_id:)
+    clerk_double(user_id:, include_org: false, include_role: false)
+  end
+
+  it "returns nil for everything when clerk is nil" do
+    resolver = described_class.new(nil)
+
+    expect(resolver.user).to be_nil
+    expect(resolver.org).to be_nil
+    expect(resolver.role).to be_nil
+  end
+
+  describe "#user" do
+    let(:clerk) { clerk_double(user_id: "user_abc", organization_id: nil) }
+
+    it "finds or creates the user" do
+      expect { described_class.new(clerk).user }.to change(User, :count).by(1)
+      expect(User.find_by(clerk_id: "user_abc")).to be_present
+    end
+
+    it "does not recreate an existing user" do
+      create(:user, clerk_id: "user_abc")
+
+      expect { described_class.new(clerk).user }.not_to change(User, :count)
+    end
+
+    it "resolves the user WITHOUT touching orgs, even when an org is present" do
+      with_org = clerk_double(user_id: "user_abc", organization_id: "org_xyz", organization_role: "org:admin")
+      resolver = described_class.new(with_org)
+
+      expect { resolver.user }.not_to change(Org, :count)
+    end
+
+    it "recovers from a concurrent-creation race instead of raising" do
+      existing = create(:user, clerk_id: "user_abc")
+      # Simulate losing the INSERT race: the unique index rejects the create.
+      allow(User).to receive(:find_or_create_by).and_raise(ActiveRecord::RecordNotUnique)
+
+      expect(described_class.new(clerk).user).to eq(existing)
+    end
+  end
+
+  describe "#org" do
+    it "finds or creates the Org anchor for the active org" do
+      clerk = clerk_double(user_id: "user_abc", organization_id: "org_xyz", organization_role: "org:admin")
+
+      expect { described_class.new(clerk).org }.to change(Org, :count).by(1)
+      expect(Org.find_by(clerk_org_id: "org_xyz")).to be_present
+    end
+
+    it "finds the existing Org anchor instead of creating a duplicate" do
+      create(:org, clerk_org_id: "org_xyz")
+      clerk = clerk_double(user_id: "user_abc", organization_id: "org_xyz")
+
+      expect { described_class.new(clerk).org }.not_to change(Org, :count)
+    end
+
+    it "is nil when the user is in no organization (mixed setup)" do
+      existing_org = create(:org)
+      clerk = clerk_double(user_id: "user_abc", organization_id: nil)
+
+      resolver = described_class.new(clerk)
+      expect { resolver.org }.not_to change(Org, :count)
+      expect(resolver.org).to be_nil
+      expect(Org.exists?(existing_org.id)).to be(true) # unrelated orgs untouched
+    end
+
+    it "is nil and does not raise when Clerk organizations are disabled" do
+      resolver = described_class.new(clerk_double_without_orgs(user_id: "user_abc"))
+
+      expect { resolver.org }.not_to change(Org, :count)
+      expect(resolver.org).to be_nil
+    end
+
+    it "resolves the org anchor even when there is no user" do
+      clerk = clerk_double(user_id: nil, organization_id: "org_xyz", organization_role: "org:admin")
+
+      resolver = described_class.new(clerk)
+      expect(resolver.user).to be_nil
+      expect(resolver.org).to eq(Org.find_by(clerk_org_id: "org_xyz"))
+    end
+  end
+
+  describe "#role" do
+    it "is read live from the token, not persisted" do
+      clerk = clerk_double(user_id: "user_abc", organization_id: "org_xyz", organization_role: "org:admin")
+      expect(described_class.new(clerk).role).to eq("org:admin")
+
+      promoted = clerk_double(user_id: "user_abc", organization_id: "org_xyz", organization_role: "org:member")
+      expect(described_class.new(promoted).role).to eq("org:member")
+    end
+
+    it "is nil when the proxy does not expose organization_role" do
+      clerk = clerk_double(user_id: "user_abc", organization_id: "org_xyz", include_role: false)
+
+      expect(described_class.new(clerk).role).to be_nil
+    end
+  end
+end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -22,7 +22,8 @@ module AuthenticationHelpers
       double("clerk_proxy",
         user?: true,
         user_id: user.clerk_id,
-        organization_id: nil
+        organization_id: nil,
+        organization_role: nil
       )
     )
   end


### PR DESCRIPTION
Move the find-or-create-on-read logic out of the Authenticatable concern
into ClerkAuthenticationResolver, resolved once per request. User and Org
remain thin local ID anchors (so app data can foreign-key to them); they
do not mirror Clerk-managed data.

The user's active-org role is read live from the Clerk token
(clerk.organization_role) rather than persisted locally. Clerk is the
source of truth for org membership and roles, so mirroring them would only
add drift and a partial, request-scoped view. Org/role resolution is
respond_to?-guarded so it works whether Clerk orgs are disabled or the
user is in a personal/no-org context.

Also reduce the Clerk profile cache TTL from 24h to 1h
(User::CLERK_CACHE_TTL) and share the cache key via User.clerk_cache_key
so the user.updated webhook reuses it.

https://claude.ai/code/session_01TtqjKeK2spSByHokdntZmq