### PR TITLE
Update CI: align Node version with .tool-versions, use npm ci, add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   lint_js:
@@ -16,11 +20,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: '.tool-versions'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Audit npm dependencies for known vulnerabilities
         run: npm audit --audit-level=high
@@ -101,7 +105,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: '.tool-versions'
           cache: 'npm'
 
       - name: Install npm dependencies


### PR DESCRIPTION
- Read Node version from .tool-versions (24.1.0) instead of hardcoding 22,
  keeping CI in sync with the project's declared toolchain
- Use 'npm ci' in lint_js for deterministic, lockfile-respecting installs
  (matching the test job)
- Cancel superseded in-progress runs on PRs to save runner minutes