### PR TITLE
Fix Inertia page-resolution crash and tidy auth/webhook code

### DIFF
--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -38,13 +38,4 @@ module Authenticatable
   def current_org
     clerk_auth.org
   end
-
-  def org_account?
-    current_org.present?
-  end
-
-  # The user's role in the active org, read live from the Clerk token.
-  def current_user_org_role
-    clerk_auth.role
-  end
 end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -43,8 +43,10 @@ class WebhooksController < ApplicationController
   end
 
   def handle_user_deleted(data)
-    # Clerk webhook payload structure: data contains the user object
-    clerk_user_id = data[:id] || data["id"]
+    # Clerk webhook payload structure: data contains the user object.
+    # `data` is ActionController::Parameters, which already supports both
+    # symbol and string keys, so a single lookup is enough.
+    clerk_user_id = data[:id]
 
     user = User.find_by(clerk_id: clerk_user_id)
     if user
@@ -56,7 +58,7 @@ class WebhooksController < ApplicationController
   end
 
   def handle_user_updated(data)
-    clerk_user_id = data[:id] || data["id"]
+    clerk_user_id = data[:id]
 
     user = User.find_by(clerk_id: clerk_user_id)
     if user

--- a/app/frontend/components/form.tsx
+++ b/app/frontend/components/form.tsx
@@ -81,7 +81,7 @@ const FormField = <
       id: string
       name: string
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-      onKeyPress: () => void
+      onKeyDown: () => void
       value: FormDataConvertible
     }
   }) => React.ReactNode
@@ -103,7 +103,7 @@ interface FieldProps {
   id: string
   name: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onKeyPress: () => void
+  onKeyDown: () => void
   value: FormDataConvertible
 }
 
@@ -126,7 +126,9 @@ const Renderer = ({
       name,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         form.setData(name, e.target.value),
-      onKeyPress: () => {
+      // Clear a field's error as soon as the user starts correcting it.
+      // (React deprecated onKeyPress in favour of onKeyDown.)
+      onKeyDown: () => {
         if (form.errors[name]) {
           form.clearErrors(name)
         }

--- a/app/frontend/entrypoints/inertia.ts
+++ b/app/frontend/entrypoints/inertia.ts
@@ -1,10 +1,10 @@
 import { createInertiaApp } from "@inertiajs/react"
-import { type ReactNode, createElement } from "react"
+import { createElement } from "react"
 import { createRoot } from "react-dom/client"
 
 import { ErrorBoundary } from "@/components/error-boundary"
 import { initializeTheme } from "@/hooks/use-appearance"
-import PersistentLayout from "@/layouts/persistent-layout"
+import { type ResolvedComponent, resolvePage } from "@/lib/resolve-page"
 
 // Initialize Sentry for error tracking in production only
 if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
@@ -33,11 +33,6 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   })
 }
 
-// Temporary type definition, until @inertiajs/react provides one
-interface ResolvedComponent {
-  default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
-}
-
 const appName = (import.meta.env.VITE_APP_NAME ?? "Rails") as string
 
 void createInertiaApp({
@@ -50,19 +45,7 @@ void createInertiaApp({
     const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.tsx", {
       eager: true,
     })
-    const page = pages[`../pages/${name}.tsx`]
-    if (!page) {
-      console.error(`Missing Inertia page component: '${name}.tsx'`)
-    }
-
-    // To use a default layout, import the Layout component
-    // and use the following line.
-    // see https://inertia-rails.dev/guide/pages#default-layouts
-    //
-    page.default.layout ??= (page) =>
-      createElement(PersistentLayout, null, page)
-
-    return page
+    return resolvePage(pages, name)
   },
 
   setup({ el, App, props }) {

--- a/app/frontend/lib/resolve-page.ts
+++ b/app/frontend/lib/resolve-page.ts
@@ -1,0 +1,34 @@
+import { type ReactNode, createElement } from "react"
+
+import PersistentLayout from "@/layouts/persistent-layout"
+
+// Temporary type definition, until @inertiajs/react provides one
+export interface ResolvedComponent {
+  default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
+}
+
+// Shared page resolver for the client (entrypoints/inertia.ts) and SSR
+// (ssr/ssr.ts) entrypoints, which previously duplicated this logic verbatim.
+//
+// `pages` is the eagerly-globbed module map; callers must run `import.meta.glob`
+// themselves because it is a compile-time Vite transform that has to live in the
+// entrypoint module.
+export function resolvePage(
+  pages: Record<string, ResolvedComponent>,
+  name: string,
+): ResolvedComponent {
+  const page = pages[`../pages/${name}.tsx`]
+
+  // Fail loudly with an actionable message. Returning here (or merely logging)
+  // would crash one line later on `page.default` with an opaque TypeError that
+  // hides which component is missing.
+  if (!page) {
+    throw new Error(`Missing Inertia page component: '${name}.tsx'`)
+  }
+
+  // To use a default layout, every page falls back to the persistent layout.
+  // see https://inertia-rails.dev/guide/pages#default-layouts
+  page.default.layout ??= (page) => createElement(PersistentLayout, null, page)
+
+  return page
+}

--- a/app/frontend/lib/resolve-page.ts
+++ b/app/frontend/lib/resolve-page.ts
@@ -1,10 +1,12 @@
-import { type ReactNode, createElement } from "react"
+import { type ComponentType, type ReactNode, createElement } from "react"
 
 import PersistentLayout from "@/layouts/persistent-layout"
 
-// Temporary type definition, until @inertiajs/react provides one
+// Temporary type definition, until @inertiajs/react provides one. A page module's
+// default export is a React component (function/class), optionally carrying a
+// `layout` wrapper — not a rendered node.
 export interface ResolvedComponent {
-  default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
+  default: ComponentType & { layout?: (page: ReactNode) => ReactNode }
 }
 
 // Shared page resolver for the client (entrypoints/inertia.ts) and SSR

--- a/app/frontend/ssr/ssr.ts
+++ b/app/frontend/ssr/ssr.ts
@@ -1,15 +1,10 @@
 import { createInertiaApp } from "@inertiajs/react"
 import createServer from "@inertiajs/react/server"
-import { type ReactNode, createElement } from "react"
+import { createElement } from "react"
 import ReactDOMServer from "react-dom/server"
 
 import { ErrorBoundary } from "@/components/error-boundary"
-import PersistentLayout from "@/layouts/persistent-layout"
-
-// Temporary type definition, until @inertiajs/react provides one
-interface ResolvedComponent {
-  default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
-}
+import { type ResolvedComponent, resolvePage } from "@/lib/resolve-page"
 
 const appName = (import.meta.env.VITE_APP_NAME ?? "Rails") as string
 
@@ -22,19 +17,7 @@ createServer((page) =>
       const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.tsx", {
         eager: true,
       })
-      const page = pages[`../pages/${name}.tsx`]
-      if (!page) {
-        console.error(`Missing Inertia page component: '${name}.tsx'`)
-      }
-
-      // To use a default layout, import the Layout component
-      // and use the following line.
-      // see https://inertia-rails.dev/guide/pages#default-layouts
-      //
-      page.default.layout ??= (page) =>
-        createElement(PersistentLayout, null, page)
-
-      return page
+      return resolvePage(pages, name)
     },
     setup: ({ App, props }) =>
       createElement(ErrorBoundary, null, createElement(App, props)),

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :request do
+  describe "GET /dashboard" do
+    context "when signed in" do
+      let(:user) { create(:user) }
+
+      before { sign_in_as user }
+
+      it "returns http success" do
+        get dashboard_url
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when signed out" do
+      it "redirects to sign in" do
+        get dashboard_url
+        expect(response).to redirect_to(sign_in_url)
+      end
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Home", type: :request do
+  describe "GET /" do
+    it "is publicly accessible without authentication" do
+      get root_url
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not redirect signed-out visitors to sign in" do
+      get root_url
+      expect(response).not_to redirect_to(sign_in_url)
+    end
+  end
+end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe "Webhooks", type: :request do
       end
     end
 
+    context "when an unhandled event type is received" do
+      it "logs the event and still responds 200 so Svix does not retry" do
+        allow(Rails.logger).to receive(:info)
+
+        post webhooks_clerk_url, params: {
+          type: "user.created",
+          data: {id: "user_unhandled"}
+        }
+
+        expect(Rails.logger).to have_received(:info).with("Unhandled Clerk webhook event: user.created")
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context "when the same delivery is retried (idempotency)" do
       it "processes a given svix-id only once" do
         # Use a real cache store so the unless_exist guard actually persists


### PR DESCRIPTION
## Summary

A round of code improvements: one real bug fix, a deprecation cleanup, dead-code removal, and filled-in test coverage. All quality gates pass locally (tsc, eslint, prettier, vitest, rspec, rubocop).

## Changes

### 🐛 Bug fix — Inertia page resolution
The client (`entrypoints/inertia.ts`) and SSR (`ssr/ssr.ts`) entrypoints duplicated the page resolver. When a page component couldn't be resolved, the code logged a helpful `Missing Inertia page component` message and then **immediately dereferenced the `undefined` module** (`page.default.layout ??= …`), crashing with an opaque `TypeError` that hid the actual cause.

- Extracted the shared logic into `app/frontend/lib/resolve-page.ts`.
- It now `throw`s a clear, actionable error instead of crashing one line later.

### 🧹 Frontend cleanup
- Replaced the deprecated `onKeyPress` field handler in `components/form.tsx` with `onKeyDown` (React deprecated `onKeyPress`).

### 🧹 Backend cleanup
- Removed the unused `org_account?` and `current_user_org_role` helpers from `Authenticatable`.
- Dropped the redundant `data[:id] || data["id"]` lookups in the Clerk webhook handlers — `ActionController::Parameters` already supports indifferent access.

### 🧪 Tests
- Renamed the misnamed `spec/requests/users_spec.rb` → `webhooks_spec.rb` (its contents are entirely webhook specs) and added coverage for the unhandled-event-type branch.
- Added request specs for the public Home page and the authenticated Dashboard.

## Verification
- `npx tsc -p tsconfig.app.json` — clean (only the pre-existing `baseUrl` deprecation, present on `main`)
- `npm run lint` / `prettier --check` — clean
- `vitest run` — 5 passed
- `bundle exec rspec` — 63 examples, 0 failures
- `rubocop` — no offenses

https://claude.ai/code/session_01RHh9RrigqipU1uQdvd5YGP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHh9RrigqipU1uQdvd5YGP)_