### PR TITLE
Make setup script more robust (credentials, .env, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,59 @@ A modern full-stack starter application with Rails backend and React frontend us
 ## Setup
 
 1. Clone this repository
-2. Set up environment variables (see [Environment Variables](#environment-variables))
-3. Setup dependencies & run the server:
+2. Run the setup script:
    ```bash
    bin/setup
    ```
+   `bin/setup` is idempotent and will, in order:
+   - Install Ruby (Bundler) and JavaScript (npm) dependencies.
+   - Create a `.env` file from `.env.example` if one doesn't already exist.
+   - Make sure your Rails encrypted credentials can be decrypted (see
+     [Rails Credentials & the Master Key](#rails-credentials--the-master-key)).
+   - Prepare the database and clear old logs/tempfiles.
+   - Start the development server (pass `--skip-server` to stop before this).
+3. Fill in your secrets (the script will remind you at the end):
+   - Edit `.env` and set `VITE_CLERK_PUBLISHABLE_KEY` (and any other keys you need).
+   - Edit your Rails credentials with `bin/rails credentials:edit` (Clerk
+     `secret_key` / `webhook_secret`, Resend `api_key`, etc.).
+   - See [Environment Variables](#environment-variables) for the full list.
 4. Open http://localhost:3000
+
+### What you need before you start
+
+- **Ruby** and **Node.js** matching the versions in `.ruby-version` and `.tool-versions`.
+- A **Clerk** account for authentication ([sign up](https://clerk.com)) — you'll need a
+  publishable key (for `.env`) and a secret key (for Rails credentials).
+- The **Rails master key** for this app's encrypted credentials. The encrypted
+  `config/credentials.yml.enc` is committed to the repo, but `config/master.key`
+  is intentionally **not** (it's gitignored). See below.
+
+### Rails Credentials & the Master Key
+
+Rails stores secrets in an encrypted file, `config/credentials.yml.enc`, which is
+decrypted with `config/master.key` (or the `RAILS_MASTER_KEY` environment
+variable). The master key is gitignored and never committed, so a fresh clone has
+the encrypted file but no key to read it.
+
+`bin/setup` detects this situation and offers three choices:
+
+1. **Enter the existing master key** — paste the key shared securely by a teammate
+   (or your secrets manager). The script writes it to `config/master.key`.
+2. **Delete and regenerate** — permanently deletes the existing
+   `config/credentials.yml.enc`, then runs `bin/rails credentials:edit` to create a
+   brand new master key and credentials file. Use this if you don't have the
+   original key (e.g. you're starting your own project from this template). You'll
+   need to re-add every secret afterwards — see `config/credentials.yml.example`
+   for the expected structure.
+3. **Skip** — leave it for now and fix it manually before booting the app.
+
+You can also set `RAILS_MASTER_KEY` in your environment instead of using a
+`config/master.key` file (recommended for production / CI).
+
+To view or edit credentials at any time:
+```bash
+bin/rails credentials:edit
+```
 
 ## Environment Variables
 

--- a/bin/setup
+++ b/bin/setup
@@ -7,6 +7,89 @@ def system!(*args)
   system(*args, exception: true)
 end
 
+# Ask the user a yes/no question. Returns true for yes.
+def prompt_yes?(question, default: false)
+  suffix = default ? "[Y/n]" : "[y/N]"
+  print "#{question} #{suffix} "
+  answer = $stdin.gets&.strip
+  return default if answer.nil? || answer.empty?
+
+  answer.downcase.start_with?("y")
+end
+
+# Ensure a .env file exists by copying from .env.example.
+def setup_env_file
+  if File.exist?(".env")
+    puts "  .env already exists, skipping."
+    return false
+  end
+
+  unless File.exist?(".env.example")
+    puts "  No .env.example found, skipping."
+    return false
+  end
+
+  FileUtils.cp ".env.example", ".env"
+  puts "  Created .env from .env.example."
+  true
+end
+
+# Ensure Rails encrypted credentials can be decrypted.
+#
+# A common pitfall: config/credentials.yml.enc is committed, but
+# config/master.key is gitignored. A fresh clone therefore has the
+# encrypted file but no key to decrypt it. Handle that case gracefully.
+def setup_credentials
+  enc_file = "config/credentials.yml.enc"
+  key_file = "config/master.key"
+
+  # Nothing to decrypt and no key: rails credentials:edit will create both.
+  return true if !File.exist?(enc_file) && !File.exist?(key_file)
+
+  # Key present (file or env var): we're good.
+  return true if File.exist?(key_file) || ENV["RAILS_MASTER_KEY"]
+
+  # We have an encrypted credentials file but no master key.
+  puts "\n  WARNING: #{enc_file} exists but #{key_file} is missing."
+  puts "  Without the master key, the encrypted credentials cannot be decrypted."
+  puts
+  puts "  How would you like to proceed?"
+  puts "    1) Enter the existing master key (paste it now)"
+  puts "    2) Delete the existing credentials and generate a brand new set"
+  puts "    3) Skip for now (you'll need to fix this manually before booting)"
+  print "  Choose [1/2/3]: "
+  choice = $stdin.gets&.strip
+
+  case choice
+  when "1"
+    print "  Paste your master key: "
+    master_key = $stdin.gets&.strip
+    if master_key.nil? || master_key.empty?
+      puts "  No key entered. Skipping credentials setup."
+      return false
+    end
+    File.write(key_file, master_key)
+    FileUtils.chmod(0o600, key_file)
+    puts "  Wrote #{key_file}."
+    true
+  when "2"
+    unless prompt_yes?("  This will PERMANENTLY DELETE #{enc_file}. Are you sure?")
+      puts "  Aborted. Skipping credentials setup."
+      return false
+    end
+    FileUtils.rm_f(enc_file)
+    FileUtils.rm_f(key_file)
+    puts "  Deleted #{enc_file}. A new credentials file will be generated."
+    puts "  Opening the credentials editor (set EDITOR if it doesn't open)..."
+    # `rails credentials:edit` generates a fresh master.key + credentials.yml.enc.
+    system("bin/rails credentials:edit")
+    File.exist?(key_file)
+  else
+    puts "  Skipping credentials setup. Fix this before booting the app."
+    false
+  end
+end
+
 FileUtils.chdir APP_ROOT do
   # This script is a way to set up or update your development environment automatically.
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
@@ -18,16 +101,28 @@ FileUtils.chdir APP_ROOT do
   # Install JavaScript dependencies
   system("npm install --check-files")
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?("config/database.yml")
-  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
-  # end
+  puts "\n== Setting up environment variables =="
+  env_created = setup_env_file
+
+  puts "\n== Setting up Rails credentials =="
+  credentials_ready = setup_credentials
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Setup complete =="
+  if env_created
+    puts "  * Edit .env and set VITE_CLERK_PUBLISHABLE_KEY (and any other keys you need)."
+  end
+  unless credentials_ready
+    puts "  * Rails credentials are not ready yet. Run `bin/rails credentials:edit` to configure them."
+  end
+  puts "  * Edit your Rails credentials with `bin/rails credentials:edit`"
+  puts "    (add your Clerk secret_key, webhook_secret, Resend api_key, etc.)."
+  puts "  * See the README \"Environment Variables\" section for the full list of required values."
 
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="


### PR DESCRIPTION
## Summary

Makes `bin/setup` more robust around the common "fresh clone" pain points, and documents the requirements in the README.

The repo commits `config/credentials.yml.enc` but gitignores `config/master.key`, so a fresh clone has the encrypted credentials file with no key to decrypt it. The setup script now detects and handles this.

## Changes

**`bin/setup`**
- **Missing master key handling:** When `config/credentials.yml.enc` exists but `config/master.key` is missing (and `RAILS_MASTER_KEY` is unset), prompt the user with three choices:
  1. Enter/paste the existing master key (written to `config/master.key` with `0600` perms)
  2. Delete the existing credentials and generate a brand new set via `rails credentials:edit` (with a confirmation guard before deleting)
  3. Skip for now
- **`.env` bootstrap:** Copy `.env.example` → `.env` when no `.env` exists.
- **Closing reminders:** Print guidance at the end to edit both `.env` and the Rails credentials, pointing to the README.
- Removed the stale commented-out `database.yml` sample block.

**`README.md`**
- Expanded the Setup section to describe exactly what `bin/setup` does step by step.
- Added a "What you need before you start" prerequisites list (Ruby/Node versions, Clerk account, the Rails master key).
- Added a "Rails Credentials & the Master Key" section explaining why `master.key` isn't committed and walking through the three setup choices.

## Notes
- The script remains idempotent — re-running it skips `.env` creation and credential setup when already configured.
- All prompts read from stdin; non-interactive runs fall back to safe defaults (skip).

https://claude.ai/code/session_018mHabJSyG5MR5kVGdkpVn7

---
_Generated by [Claude Code](https://claude.ai/code/session_018mHabJSyG5MR5kVGdkpVn7)_